### PR TITLE
Update mapper to allow usage of all basetypes, including column references

### DIFF
--- a/spark_auto_mapper/data_types/map.py
+++ b/spark_auto_mapper/data_types/map.py
@@ -18,7 +18,8 @@ class AutoMapperMapDataType(AutoMapperDataTypeExpression):
     def __init__(
         self,
         column: AutoMapperColumnOrColumnLikeType,
-        mapping: Dict[AutoMapperTextInputType, AutoMapperAnyDataType],
+        mapping: Dict[Optional[AutoMapperTextInputType],
+                      AutoMapperAnyDataType],
         default: Optional[AutoMapperAnyDataType] = None
     ):
         super().__init__(value="")

--- a/spark_auto_mapper/helpers/automapper_helpers.py
+++ b/spark_auto_mapper/helpers/automapper_helpers.py
@@ -243,7 +243,8 @@ class AutoMapperHelpers:
     @staticmethod
     def map(
         column: AutoMapperColumnOrColumnLikeType,
-        mapping: Dict[AutoMapperTextInputType, AutoMapperAnyDataType],
+        mapping: Dict[Optional[AutoMapperTextInputType],
+                      AutoMapperAnyDataType],
         default: Optional[AutoMapperAnyDataType] = None
     ) -> AutoMapperDataTypeExpression:
         """

--- a/tests/map/test_automapper_map_null.py
+++ b/tests/map/test_automapper_map_null.py
@@ -1,0 +1,67 @@
+from typing import Dict
+
+from pyspark.sql import SparkSession, Column, DataFrame
+# noinspection PyUnresolvedReferences
+from pyspark.sql.functions import col, when, lit
+
+from spark_auto_mapper.automappers.automapper import AutoMapper
+from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
+
+
+def test_automapper_map(spark_session: SparkSession) -> None:
+    # Arrange
+    spark_session.createDataFrame(
+        [
+            (1, 'Qureshi', 'Imran', "Y"),
+            (2, 'Vidal', 'Michael', "N"),
+            (3, 'Vidal', 'Michael', "f"),
+            (4, 'Qureshi', 'Imran', None),
+        ], ['member_id', 'last_name', 'first_name', "has_kids"]
+    ).createOrReplaceTempView("patients")
+
+    source_df: DataFrame = spark_session.table("patients")
+
+    df = source_df.select("member_id")
+    df.createOrReplaceTempView("members")
+
+    # Act
+    mapper = AutoMapper(
+        view="members", source_view="patients", keys=["member_id"]
+    ).columns(
+        has_kids=A.map(
+            A.column("has_kids"), {
+                None: "Unspecified",
+                "Y": "Yes",
+                "N": "No"
+            }, "unknown"
+        )
+    )
+
+    assert isinstance(mapper, AutoMapper)
+    sql_expressions: Dict[str, Column] = mapper.get_column_specs(
+        source_df=source_df
+    )
+    for column_name, sql_expression in sql_expressions.items():
+        print(f"{column_name}: {sql_expression}")
+
+    assert str(sql_expressions["has_kids"]) == str(
+        when(col("b.has_kids").eqNullSafe(lit(None)), lit("Unspecified")).when(
+            col("b.has_kids").eqNullSafe(lit("Y")), lit("Yes")
+        ).when(col("b.has_kids").eqNullSafe(lit("N")),
+               lit("No")).otherwise(lit("unknown")).alias("___has_kids")
+    )
+
+    result_df: DataFrame = mapper.transform(df=df)
+
+    # Assert
+    result_df.printSchema()
+    result_df.show()
+
+    assert result_df.where("member_id == 1").select("has_kids"
+                                                    ).collect()[0][0] == "Yes"
+    assert result_df.where("member_id == 2").select("has_kids"
+                                                    ).collect()[0][0] == "No"
+    assert result_df.where("member_id == 3"
+                           ).select("has_kids").collect()[0][0] == "unknown"
+    assert result_df.where("member_id == 4").select("has_kids").collect(
+    )[0][0] == "Unspecified"


### PR DESCRIPTION
Allows the value to fall back to the original value if it can't be matched, or could use another column, etc