### PR TITLE
Fix so AutoMapperDataTypeLiteral("") is a literal empty string rather than NULL

### DIFF
--- a/spark_auto_mapper/data_types/literal.py
+++ b/spark_auto_mapper/data_types/literal.py
@@ -26,7 +26,7 @@ class AutoMapperDataTypeLiteral(AutoMapperTextLikeBase):
     def get_column_spec(
         self, source_df: Optional[DataFrame], current_column: Optional[Column]
     ) -> Column:
-        if not self.value:
+        if self.value is None:
             return lit(None)
         if isinstance(self.value, str) or isinstance(self.value, int) \
                 or isinstance(self.value, float) or isinstance(self.value, date) \

--- a/tests/literal/test_literal.py
+++ b/tests/literal/test_literal.py
@@ -6,7 +6,6 @@ from pyspark.sql.functions import lit
 
 from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.data_types.literal import AutoMapperDataTypeLiteral
-from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
 
 
 def test_auto_mapper_datatype_literal(spark_session: SparkSession) -> None:
@@ -19,9 +18,6 @@ def test_auto_mapper_datatype_literal(spark_session: SparkSession) -> None:
     ).createOrReplaceTempView("patients")
 
     source_df: DataFrame = spark_session.table("patients")
-
-    # example of a variable
-    client_address_variable: str = "address1"
 
     # Act
     mapper = AutoMapper(
@@ -63,6 +59,22 @@ def test_auto_mapper_datatype_literal(spark_session: SparkSession) -> None:
     result = result_df.collect()
 
     assert result == [
-        Row(member_id=1, dst1='src1', dst2=None, dst3='', dst4='literal', dst5=1234, dst6=0), 
-        Row(member_id=2, dst1='src1', dst2=None, dst3='', dst4='literal', dst5=1234, dst6=0), 
+        Row(
+            member_id=1,
+            dst1='src1',
+            dst2=None,
+            dst3='',
+            dst4='literal',
+            dst5=1234,
+            dst6=0
+        ),
+        Row(
+            member_id=2,
+            dst1='src1',
+            dst2=None,
+            dst3='',
+            dst4='literal',
+            dst5=1234,
+            dst6=0
+        ),
     ]

--- a/tests/literal/test_literal.py
+++ b/tests/literal/test_literal.py
@@ -1,0 +1,68 @@
+from typing import Dict
+
+from pyspark.sql import SparkSession, Column, DataFrame, Row
+# noinspection PyUnresolvedReferences
+from pyspark.sql.functions import lit
+
+from spark_auto_mapper.automappers.automapper import AutoMapper
+from spark_auto_mapper.data_types.literal import AutoMapperDataTypeLiteral
+from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
+
+
+def test_auto_mapper_datatype_literal(spark_session: SparkSession) -> None:
+    # Arrange
+    spark_session.createDataFrame(
+        [
+            (1, 'Qureshi', 'Imran'),
+            (2, 'Vidal', 'Michael'),
+        ], ['member_id', 'last_name', 'first_name']
+    ).createOrReplaceTempView("patients")
+
+    source_df: DataFrame = spark_session.table("patients")
+
+    # example of a variable
+    client_address_variable: str = "address1"
+
+    # Act
+    mapper = AutoMapper(
+        view="members",
+        source_view="patients",
+        keys=["member_id"],
+        drop_key_columns=False
+    ).columns(
+        dst1="src1",
+        dst2=AutoMapperDataTypeLiteral(None),
+        dst3=AutoMapperDataTypeLiteral(""),
+        dst4=AutoMapperDataTypeLiteral("literal"),
+        dst5=AutoMapperDataTypeLiteral(1234),
+        dst6=AutoMapperDataTypeLiteral(0),
+    )
+
+    assert isinstance(mapper, AutoMapper)
+
+    sql_expressions: Dict[str, Column] = mapper.get_column_specs(
+        source_df=source_df
+    )
+
+    for column_name, sql_expression in sql_expressions.items():
+        print(f"{column_name}: {sql_expression}")
+
+    assert str(sql_expressions["dst1"]) == str(lit("src1").alias("dst1"))
+    assert str(sql_expressions["dst2"]) == str(lit(None).alias("dst2"))
+    assert str(sql_expressions["dst3"]) == str(lit("").alias("dst3"))
+    assert str(sql_expressions["dst4"]) == str(lit("literal").alias("dst4"))
+    assert str(sql_expressions["dst5"]) == str(lit(1234).alias("dst5"))
+    assert str(sql_expressions["dst6"]) == str(lit(0).alias("dst6"))
+
+    result_df: DataFrame = mapper.transform(df=source_df)
+
+    # Assert
+    result_df.printSchema()
+    result_df.show()
+
+    result = result_df.collect()
+
+    assert result == [
+        Row(member_id=1, dst1='src1', dst2=None, dst3='', dst4='literal', dst5=1234, dst6=0), 
+        Row(member_id=2, dst1='src1', dst2=None, dst3='', dst4='literal', dst5=1234, dst6=0), 
+    ]

--- a/tests/map/test_automapper_map_col_default.py
+++ b/tests/map/test_automapper_map_col_default.py
@@ -45,12 +45,10 @@ def test_automapper_map(spark_session: SparkSession) -> None:
                 "N": "No"
             }, lit("TRUE")
         ),
-        blank_col=A.map(
-            A.column("has_kids"), {
-                "Y": "Yes",
-                "N": "No"
-            }, ""
-        )
+        blank_col=A.map(A.column("has_kids"), {
+            "Y": "Yes",
+            "N": "No"
+        }, "")
     )
 
     assert isinstance(mapper, AutoMapper)

--- a/tests/map/test_automapper_map_col_default.py
+++ b/tests/map/test_automapper_map_col_default.py
@@ -44,6 +44,12 @@ def test_automapper_map(spark_session: SparkSession) -> None:
                 "Y": "Yes",
                 "N": "No"
             }, lit("TRUE")
+        ),
+        blank_col=A.map(
+            A.column("has_kids"), {
+                "Y": "Yes",
+                "N": "No"
+            }, ""
         )
     )
 
@@ -91,3 +97,5 @@ def test_automapper_map(spark_session: SparkSession) -> None:
                                                     ).collect()[0][0] == "f"
     assert result_df.where("member_id == 3").select("lit_col"
                                                     ).collect()[0][0] == "TRUE"
+    assert result_df.where("member_id == 3").select("blank_col"
+                                                    ).collect()[0][0] == ""


### PR DESCRIPTION
Any falsey value, including "", 0, [], etc were being replaced by NULL.
Changing implicit falsiness check with an explicit is None check.