### PR TITLE
Globalize handling of python reserved words in AutoMapper

### DIFF
--- a/spark_auto_mapper/automappers/automapper.py
+++ b/spark_auto_mapper/automappers/automapper.py
@@ -19,8 +19,6 @@ from spark_auto_mapper.type_definitions.defined_types import AutoMapperAnyDataTy
 
 TEMPORARY_KEY = "__row_id"
 
-raise KeyError("WTF!?!?!?!?!")
-
 
 class AutoMapper(AutoMapperContainer):
     # noinspection PyDefaultArgument

--- a/spark_auto_mapper/automappers/automapper.py
+++ b/spark_auto_mapper/automappers/automapper.py
@@ -19,6 +19,8 @@ from spark_auto_mapper.type_definitions.defined_types import AutoMapperAnyDataTy
 
 TEMPORARY_KEY = "__row_id"
 
+raise KeyError("WTF!?!?!?!?!")
+
 
 class AutoMapper(AutoMapperContainer):
     # noinspection PyDefaultArgument
@@ -354,7 +356,14 @@ class AutoMapper(AutoMapperContainer):
     # noinspection PyMethodMayBeStatic,PyPep8Naming
     def columns(self, **kwargs: AutoMapperAnyDataType) -> 'AutoMapper':
         from spark_auto_mapper.automappers.columns import AutoMapperColumns
-        columns_mapper: AutoMapperColumns = AutoMapperColumns(**kwargs)
+        # To work around protected keywords as column names, allow a trailing underscore in the definition that gets
+        # stripped at registration time.
+        col_spec = {
+            column_name[:-1] if column_name and column_name != '_'
+            and column_name.endswith("_") else column_name: column_def
+            for column_name, column_def in kwargs.items()
+        }
+        columns_mapper: AutoMapperColumns = AutoMapperColumns(**col_spec)
         for column_name, child_mapper in columns_mapper.mappers.items():
             self.register_child(dst_column=column_name, child=child_mapper)
         return self


### PR DESCRIPTION
Currently, the trick of appending an _ to an column name only works on ComplexTypes.
This allows a generic AutoMapper class to use the same logic on all AutoMapper definitions.