### PR TITLE
Update Automapper Number to be "long" instead of "int" to handle numbers larger than 2147483647

### DIFF
--- a/spark_auto_mapper/data_types/number.py
+++ b/spark_auto_mapper/data_types/number.py
@@ -24,14 +24,14 @@ class AutoMapperNumberDataType(AutoMapperDataTypeBase):
             # parse the amount here
             column_spec = self.value.get_column_spec(
                 source_df=source_df, current_column=current_column
-            ).cast("int")
+            ).cast("long")
             return column_spec
         if source_df is not None and isinstance(self.value, AutoMapperDataTypeColumn) \
                 and dict(source_df.dtypes)[self.value.value] == "string":
             # parse the amount here
             column_spec = self.value.get_column_spec(
                 source_df=source_df, current_column=current_column
-            ).cast("int")
+            ).cast("long")
             return column_spec
         else:
             column_spec = self.value.get_column_spec(

--- a/tests/complex/test_automapper_complex_with_defined_class.py
+++ b/tests/complex/test_automapper_complex_with_defined_class.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union
 from pyspark.sql import SparkSession, Column, DataFrame
 # noinspection PyUnresolvedReferences
 from pyspark.sql.functions import col
-from pyspark.sql.types import StructType, StructField, StringType, IntegerType, DataType
+from pyspark.sql.types import StructType, StructField, StringType, LongType, DataType
 
 from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.data_types.complex.complex_base import AutoMapperDataTypeComplexBase
@@ -24,7 +24,7 @@ class MyClass(AutoMapperDataTypeComplexBase):
         schema: StructType = StructType(
             [
                 StructField("name", StringType(), False),
-                StructField("age", IntegerType(), True),
+                StructField("age", LongType(), True),
             ]
         )
         return schema
@@ -69,7 +69,7 @@ def test_auto_mapper_complex_with_defined_class(
     assert str(sql_expressions["name"]
                ) == str(col("b.last_name").cast("string").alias("name"))
     assert str(sql_expressions["age"]
-               ) == str(col("b.my_age").cast("int").alias("age"))
+               ) == str(col("b.my_age").cast("long").alias("age"))
 
     result_df.printSchema()
     result_df.show()
@@ -77,4 +77,4 @@ def test_auto_mapper_complex_with_defined_class(
     assert result_df.where("member_id == 1"
                            ).select("name").collect()[0][0] == "Qureshi"
 
-    assert dict(result_df.dtypes)["age"] == "int"
+    assert dict(result_df.dtypes)["age"] in ("int", "long", "bigint")

--- a/tests/complex/test_automapper_complex_with_extension.py
+++ b/tests/complex/test_automapper_complex_with_extension.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union
 from pyspark.sql import SparkSession, Column, DataFrame
 # noinspection PyUnresolvedReferences
 from pyspark.sql.functions import col
-from pyspark.sql.types import ArrayType, IntegerType, StringType, StructField, StructType, TimestampType, DataType
+from pyspark.sql.types import ArrayType, LongType, StringType, StructField, StructType, TimestampType, DataType
 
 from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.data_types.complex.complex_base import AutoMapperDataTypeComplexBase
@@ -109,7 +109,7 @@ class MyClass(AutoMapperDataTypeComplexBase):
         schema: StructType = StructType(
             [
                 StructField("name", StringType(), False),
-                StructField("age", IntegerType(), True),
+                StructField("age", LongType(), True),
             ]
         )
         return schema
@@ -166,7 +166,7 @@ def test_auto_mapper_complex_with_extension(
     assert str(sql_expressions["name"]
                ) == str(col("b.last_name").cast("string").alias("name"))
     assert str(sql_expressions["age"]
-               ) == str(col("b.my_age").cast("int").alias("age"))
+               ) == str(col("b.my_age").cast("long").alias("age"))
 
     result_df.printSchema()
     result_df.show(truncate=False)
@@ -174,4 +174,4 @@ def test_auto_mapper_complex_with_extension(
     assert result_df.where("member_id == 1"
                            ).select("name").collect()[0][0] == "Qureshi"
 
-    assert dict(result_df.dtypes)["age"] == "int"
+    assert dict(result_df.dtypes)["age"] in ("int", "long", "bigint")

--- a/tests/complex/test_automapper_complex_with_skip_if_null.py
+++ b/tests/complex/test_automapper_complex_with_skip_if_null.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union
 from pyspark.sql import SparkSession, Column, DataFrame
 # noinspection PyUnresolvedReferences
 from pyspark.sql.functions import col, when, lit
-from pyspark.sql.types import StructType, StructField, StringType, IntegerType, DataType
+from pyspark.sql.types import StructType, StructField, StringType, LongType, DataType
 
 from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.data_types.complex.complex_base import AutoMapperDataTypeComplexBase
@@ -26,7 +26,7 @@ class MyClass(AutoMapperDataTypeComplexBase):
             [
                 StructField("id", StringType(), False),
                 StructField("name", StringType(), False),
-                StructField("age", IntegerType(), True),
+                StructField("age", LongType(), True),
             ]
         )
         return schema
@@ -83,7 +83,7 @@ def test_automapper_complex_with_skip_if_null(
         when(
             col("b.first_name").isNull() | col("b.first_name").eqNullSafe(""),
             lit(None)
-        ).otherwise(col("b.my_age")).cast(IntegerType()).alias("age")
+        ).otherwise(col("b.my_age")).cast(LongType()).alias("age")
     )
 
     result_df.printSchema()
@@ -94,4 +94,4 @@ def test_automapper_complex_with_skip_if_null(
     assert result_df.where("id == 1").select("name"
                                              ).collect()[0][0] == "Qureshi"
 
-    assert dict(result_df.dtypes)["age"] == "int"
+    assert dict(result_df.dtypes)["age"] in ("int", "long", "bigint")

--- a/tests/if_/test_automapper_if_.py
+++ b/tests/if_/test_automapper_if_.py
@@ -4,7 +4,7 @@ from pyspark.sql import SparkSession, Column, DataFrame
 # noinspection PyUnresolvedReferences
 from pyspark.sql.functions import col, when
 from pyspark.sql.functions import lit
-from pyspark.sql.types import StringType, IntegerType
+from pyspark.sql.types import StringType, LongType
 
 from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
@@ -46,8 +46,8 @@ def test_automapper_if_(spark_session: SparkSession) -> None:
     assert str(sql_expressions["age"]) == str(
         when(
             col("b.my_age").eqNullSafe(lit("54").cast(StringType())),
-            col("b.my_age").cast(IntegerType())
-        ).otherwise(lit("100").cast(StringType()).cast(IntegerType())
+            col("b.my_age").cast(LongType())
+        ).otherwise(lit("100").cast(StringType()).cast(LongType())
                     ).alias("age")
     )
 
@@ -62,4 +62,4 @@ def test_automapper_if_(spark_session: SparkSession) -> None:
     assert result_df.where("member_id == 2").select("age"
                                                     ).collect()[0][0] == 100
 
-    assert dict(result_df.dtypes)["age"] == "int"
+    assert dict(result_df.dtypes)["age"] in ("int", "long", "bigint")

--- a/tests/if_/test_automapper_if_list.py
+++ b/tests/if_/test_automapper_if_list.py
@@ -4,7 +4,7 @@ from pyspark.sql import SparkSession, Column, DataFrame
 # noinspection PyUnresolvedReferences
 from pyspark.sql.functions import col, when
 from pyspark.sql.functions import lit
-from pyspark.sql.types import StringType, IntegerType
+from pyspark.sql.types import StringType, LongType
 
 from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
@@ -46,8 +46,8 @@ def test_automapper_if_list(spark_session: SparkSession) -> None:
 
     assert str(sql_expressions["age"]) == str(
         when(col("b.my_age").isin(["54", "59"]),
-             col("b.my_age").cast("int")).otherwise(
-                 lit("100").cast(StringType()).cast(IntegerType())
+             col("b.my_age").cast("long")).otherwise(
+                 lit("100").cast(StringType()).cast(LongType())
              ).alias("age")
     )
 
@@ -63,4 +63,4 @@ def test_automapper_if_list(spark_session: SparkSession) -> None:
                                                     ).collect()[0][0] == 59
     assert result_df.where("member_id == 3").select("age"
                                                     ).collect()[0][0] == 100
-    assert dict(result_df.dtypes)["age"] == "int"
+    assert dict(result_df.dtypes)["age"] in ("int", "long", "bigint")

--- a/tests/if_not/test_automapper_if_not.py
+++ b/tests/if_not/test_automapper_if_not.py
@@ -4,7 +4,7 @@ from pyspark.sql import SparkSession, Column, DataFrame
 # noinspection PyUnresolvedReferences
 from pyspark.sql.functions import col, when
 from pyspark.sql.functions import lit
-from pyspark.sql.types import StringType, IntegerType
+from pyspark.sql.types import StringType, LongType
 
 from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
@@ -46,7 +46,7 @@ def test_automapper_if_not(spark_session: SparkSession) -> None:
         when(
             col("b.my_age").eqNullSafe(lit("55").cast(StringType())),
             lit(None)
-        ).otherwise(lit("100").cast(StringType()).cast(IntegerType())
+        ).otherwise(lit("100").cast(StringType()).cast(LongType())
                     ).alias("age")
     )
 
@@ -60,4 +60,4 @@ def test_automapper_if_not(spark_session: SparkSession) -> None:
     assert result_df.where("member_id == 1").select("age"
                                                     ).collect()[0][0] == 100
 
-    assert dict(result_df.dtypes)["age"] == "int"
+    assert dict(result_df.dtypes)["age"] in ("int", "long", "bigint")

--- a/tests/if_not/test_automapper_if_not_list.py
+++ b/tests/if_not/test_automapper_if_not_list.py
@@ -4,7 +4,7 @@ from pyspark.sql import SparkSession, Column, DataFrame
 # noinspection PyUnresolvedReferences
 from pyspark.sql.functions import col, when
 from pyspark.sql.functions import lit
-from pyspark.sql.types import StringType, IntegerType
+from pyspark.sql.types import StringType, LongType
 
 from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
@@ -45,7 +45,7 @@ def test_automapper_if_list(spark_session: SparkSession) -> None:
 
     assert str(sql_expressions["age"]) == str(
         when(col("b.my_age").isin(["64", "59"]), lit(None)).otherwise(
-            lit("100").cast(StringType()).cast(IntegerType())
+            lit("100").cast(StringType()).cast(LongType())
         ).alias("age")
     )
 
@@ -58,4 +58,4 @@ def test_automapper_if_list(spark_session: SparkSession) -> None:
     assert result_df.count() == 1
     assert result_df.where("member_id == 1").select("age"
                                                     ).collect()[0][0] == 100
-    assert dict(result_df.dtypes)["age"] == "int"
+    assert dict(result_df.dtypes)["age"] in ("int", "long", "bigint")

--- a/tests/if_not_null/test_automapper_if_not_null.py
+++ b/tests/if_not_null/test_automapper_if_not_null.py
@@ -4,7 +4,7 @@ from pyspark.sql import SparkSession, Column, DataFrame
 # noinspection PyUnresolvedReferences
 from pyspark.sql.functions import col, when
 from pyspark.sql.functions import lit
-from pyspark.sql.types import StringType, IntegerType
+from pyspark.sql.types import StringType, LongType
 
 from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
@@ -44,8 +44,8 @@ def test_automapper_if_not_null(spark_session: SparkSession) -> None:
     assert str(sql_expressions["age"]) == str(
         when(
             col("b.my_age").isNull(),
-            lit("100").cast(StringType()).cast(IntegerType())
-        ).otherwise(col("b.my_age").cast(IntegerType())).alias("age")
+            lit("100").cast(StringType()).cast(LongType())
+        ).otherwise(col("b.my_age").cast(LongType())).alias("age")
     )
 
     result_df: DataFrame = mapper.transform(df=df)
@@ -59,4 +59,4 @@ def test_automapper_if_not_null(spark_session: SparkSession) -> None:
     assert result_df.where("member_id == 2").select("age"
                                                     ).collect()[0][0] == 100
 
-    assert dict(result_df.dtypes)["age"] == "int"
+    assert dict(result_df.dtypes)["age"] in ("int", "long", "bigint")

--- a/tests/if_regex/test_automapper_if_regex.py
+++ b/tests/if_regex/test_automapper_if_regex.py
@@ -4,7 +4,7 @@ from pyspark.sql import SparkSession, Column, DataFrame
 # noinspection PyUnresolvedReferences
 from pyspark.sql.functions import col, when
 from pyspark.sql.functions import lit
-from pyspark.sql.types import StringType, IntegerType
+from pyspark.sql.types import StringType, LongType
 
 from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
@@ -45,8 +45,8 @@ def test_automapper_if_regex(spark_session: SparkSession) -> None:
 
     assert str(sql_expressions["age"]) == str(
         when(col("b.my_age").rlike("5*"),
-             col("b.my_age").cast(IntegerType())).otherwise(
-                 lit("100").cast(StringType()).cast(IntegerType())
+             col("b.my_age").cast(LongType())).otherwise(
+                 lit("100").cast(StringType()).cast(LongType())
              ).alias("age")
     )
 
@@ -61,4 +61,4 @@ def test_automapper_if_regex(spark_session: SparkSession) -> None:
     assert result_df.where("member_id == 2").select("age"
                                                     ).collect()[0][0] == 100
 
-    assert dict(result_df.dtypes)["age"] == "int"
+    assert dict(result_df.dtypes)["age"] in ("int", "long", "bigint")

--- a/tests/number/test_automapper_number_typed.py
+++ b/tests/number/test_automapper_number_typed.py
@@ -49,4 +49,4 @@ def test_auto_mapper_number_typed(spark_session: SparkSession) -> None:
     assert result_df.where("member_id == 2").select("age"
                                                     ).collect()[0][0] == 67
 
-    assert dict(result_df.dtypes)["age"] == "int"
+    assert dict(result_df.dtypes)["age"] in ("int", "long", "bigint")


### PR DESCRIPTION
Int is too small. Causing some values to be NULL. LONG (or BIGINT (same thing)) fixes.