### PR TITLE
Adding 'Optional' datatype which allows for optional source columns

### DIFF
--- a/spark_auto_mapper/data_types/optional.py
+++ b/spark_auto_mapper/data_types/optional.py
@@ -1,0 +1,55 @@
+from typing import Generic, Optional, TypeVar
+
+from pyspark.sql import Column, DataFrame
+from pyspark.sql.utils import AnalysisException
+
+from spark_auto_mapper.data_types.data_type_base import AutoMapperDataTypeBase
+from spark_auto_mapper.helpers.value_parser import AutoMapperValueParser
+from spark_auto_mapper.type_definitions.wrapper_types import AutoMapperColumnOrColumnLikeType, AutoMapperAnyDataType
+
+_TAutoMapperDataType = TypeVar(
+    "_TAutoMapperDataType", bound=AutoMapperAnyDataType
+)
+
+
+class AutoMapperOptionalType(
+    AutoMapperDataTypeBase, Generic[_TAutoMapperDataType]
+):
+    """
+    Allows for columns to be defined based in which a source column may not exist. If the optional source column does
+    not exist, the "default" column definition is used instead.
+    """
+    def __init__(
+        self,
+        column: AutoMapperColumnOrColumnLikeType,
+        default: Optional[AutoMapperColumnOrColumnLikeType],
+    ):
+        super().__init__()
+
+        self.column: AutoMapperColumnOrColumnLikeType = AutoMapperValueParser.parse_value(
+            column
+        )
+        self.default: AutoMapperColumnOrColumnLikeType = AutoMapperValueParser.parse_value(
+            default
+        )
+
+    def get_column_spec(
+        self, source_df: Optional[DataFrame], current_column: Optional[Column]
+    ) -> Column:
+        column_spec = self.column.get_column_spec(
+            source_df=source_df, current_column=current_column
+        )
+        col_name = column_spec._jc.toString(
+        )  # Get spark representation of the column
+        try:
+            # Force spark analyzer to confirm that column/expression is possible. This does not actually compute
+            # anything, just triggers the analyzer to check validity, which is what we want.
+            # If SparkSQL AnalysisException is thrown, fall-back to the default, otherwise we can proceed.
+            if source_df:
+                source_df.selectExpr(col_name.replace("b.", ""))
+        except AnalysisException:
+            column_spec = self.default.get_column_spec(
+                source_df=source_df, current_column=current_column
+            )
+
+        return column_spec

--- a/spark_auto_mapper/helpers/automapper_helpers.py
+++ b/spark_auto_mapper/helpers/automapper_helpers.py
@@ -579,6 +579,21 @@ class AutoMapperHelpers:
         )
 
     @staticmethod
+    def optional(
+        column: AutoMapperColumnOrColumnLikeType,
+        default: Optional[AutoMapperColumnOrColumnLikeType],
+    ) -> "AutoMapperDataTypeBase":
+        """
+       Allows for columns to be defined based in which a source column may not exist. If the optional source column does
+        not exist, the "default" column definition is used instead.
+
+        :return: a optional automapper type
+        """
+        from spark_auto_mapper.data_types.optional import AutoMapperOptionalType
+
+        return AutoMapperOptionalType(column=column, default=default)
+
+    @staticmethod
     def array(value: AutoMapperDataTypeBase) -> "AutoMapperDataTypeBase":
         """
         creates an array from a single item.

--- a/tests/optional/test_automapper_optional.py
+++ b/tests/optional/test_automapper_optional.py
@@ -1,0 +1,65 @@
+from typing import Dict
+
+from pyspark.sql import SparkSession, Column, DataFrame
+# noinspection PyUnresolvedReferences
+from pyspark.sql.functions import col
+from pyspark.sql.functions import lit
+
+from spark_auto_mapper.automappers.automapper import AutoMapper
+from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
+
+from spark_auto_mapper.data_types.optional import AutoMapperOptionalType
+
+
+def test_automapper_optional(spark_session: SparkSession) -> None:
+    # Arrange
+    spark_session.createDataFrame(
+        [
+            (1, 'Qureshi', 'Imran', "54"),
+            (2, 'Vidal', 'Michael', None),
+        ], ['member_id', 'last_name', 'first_name', "my_age"]
+    ).createOrReplaceTempView("patients")
+
+    source_df: DataFrame = spark_session.table("patients")
+
+    df = source_df.select("member_id")
+    df.createOrReplaceTempView("members")
+
+    # Act
+    mapper = AutoMapper(
+        view="members",
+        source_view="patients",
+        keys=["member_id"],
+        drop_key_columns=False
+    ).columns(
+        last_name=A.column("last_name"),
+        optional_age=AutoMapperOptionalType(
+            A.number(A.column("my_age")), A.text("my_age")
+        ),
+        optional_foo=AutoMapperOptionalType(A.column("foo"), A.text("foo")),
+    )
+
+    assert isinstance(mapper, AutoMapper)
+    sql_expressions: Dict[str, Column] = mapper.get_column_specs(
+        source_df=source_df
+    )
+    for column_name, sql_expression in sql_expressions.items():
+        print(f"{column_name}: {sql_expression}")
+
+    assert str(sql_expressions["optional_age"]
+               ) == str(col("b.my_age").cast("long").alias("optional_age"))
+    assert str(sql_expressions["optional_foo"]
+               ) == str(lit("foo").cast("string").alias("optional_foo"))
+
+    result_df: DataFrame = mapper.transform(df=df)
+
+    # Assert
+    result_df.printSchema()
+    result_df.show()
+
+    assert result_df.where("member_id == 1").select(
+        "optional_age", "optional_foo"
+    ).collect()[0][:] == (54, "foo")
+    assert result_df.where("member_id == 2").select(
+        "optional_age", "optional_foo"
+    ).collect()[0][:] == (None, "foo")


### PR DESCRIPTION
If the source column does not exist or can't be rendered, fall back to the "default" column definition.