### PR TITLE
Add "First_provided_column" type

### DIFF
--- a/spark_auto_mapper/data_types/first_provided_column.py
+++ b/spark_auto_mapper/data_types/first_provided_column.py
@@ -1,0 +1,63 @@
+from typing import Generic, Optional, TypeVar, List
+
+from pyspark.sql import Column, DataFrame
+from pyspark.sql.utils import AnalysisException
+
+from spark_auto_mapper.data_types.data_type_base import AutoMapperDataTypeBase
+from spark_auto_mapper.helpers.value_parser import AutoMapperValueParser
+from spark_auto_mapper.type_definitions.wrapper_types import AutoMapperColumnOrColumnLikeType, AutoMapperAnyDataType
+
+_TAutoMapperDataType = TypeVar(
+    "_TAutoMapperDataType", bound=AutoMapperAnyDataType
+)
+
+
+class AutoMapperFirstProvidedColumnType(
+    AutoMapperDataTypeBase, Generic[_TAutoMapperDataType]
+):
+    """
+    Accepts any number of column definitions and will return the first valid column definition, similar to how
+    coalesce works, but with the existence of columns rather than null values inside the columns.
+
+    Useful for data sources in which columns may be renamed at some point and you want to process files from before and
+    after the name change or when columns are added at a point and are missing from earlier files.
+    """
+    def __init__(
+        self,
+        *columns: AutoMapperColumnOrColumnLikeType,
+    ):
+        super().__init__()
+
+        self.columns: List[AutoMapperColumnOrColumnLikeType] = [
+            AutoMapperValueParser.parse_value(column) for column in columns
+        ]
+
+    def get_column_spec(
+        self, source_df: Optional[DataFrame], current_column: Optional[Column]
+    ) -> Column:
+        column_spec = None
+
+        for column in self.columns:
+            try:
+                column_spec = column.get_column_spec(
+                    source_df=source_df, current_column=current_column
+                )
+                break
+            except Exception:
+                # By definition, if we are unable to resolve a column spec, for whatever reason, the column definition
+                # is not valid and should try the next column.
+                continue
+
+            col_name = column_spec._jc.toString(
+            )  # Get spark representation of the column
+            try:
+                # Force spark analyzer to confirm that column/expression is possible. This does not actually compute
+                # anything, just triggers the analyzer to check validity, which is what we want.
+                # If SparkSQL AnalysisException is thrown, continue to next column definition
+                if source_df:
+                    source_df.selectExpr(col_name.replace("b.", ""))
+                    break  # Break as soon as the above query doesn't error as we want the FIRST provided column
+            except AnalysisException:
+                continue
+
+        return column_spec

--- a/spark_auto_mapper/data_types/first_valid_column.py
+++ b/spark_auto_mapper/data_types/first_valid_column.py
@@ -12,7 +12,7 @@ _TAutoMapperDataType = TypeVar(
 )
 
 
-class AutoMapperFirstProvidedColumnType(
+class AutoMapperFirstValidColumnType(
     AutoMapperDataTypeBase, Generic[_TAutoMapperDataType]
 ):
     """
@@ -56,7 +56,7 @@ class AutoMapperFirstProvidedColumnType(
                 # If SparkSQL AnalysisException is thrown, continue to next column definition
                 if source_df:
                     source_df.selectExpr(col_name.replace("b.", ""))
-                    break  # Break as soon as the above query doesn't error as we want the FIRST provided column
+                    break  # Break as soon as the above query doesn't error as we want the FIRST valid column
             except AnalysisException:
                 continue
 

--- a/spark_auto_mapper/helpers/automapper_helpers.py
+++ b/spark_auto_mapper/helpers/automapper_helpers.py
@@ -632,7 +632,7 @@ class AutoMapperHelpers:
         )
 
     @staticmethod
-    def first_provided_column(
+    def first_valid_column(
         *columns: AutoMapperColumnOrColumnLikeType,
     ) -> "AutoMapperDataTypeBase":
         """
@@ -641,9 +641,9 @@ class AutoMapperHelpers:
 
          :return: a optional automapper type
         """
-        from spark_auto_mapper.data_types.first_provided_column import AutoMapperFirstProvidedColumnType
+        from spark_auto_mapper.data_types.first_valid_column import AutoMapperFirstValidColumnType
 
-        return AutoMapperFirstProvidedColumnType(*columns)
+        return AutoMapperFirstValidColumnType(*columns)
 
     @staticmethod
     def optional(

--- a/spark_auto_mapper/helpers/automapper_helpers.py
+++ b/spark_auto_mapper/helpers/automapper_helpers.py
@@ -632,6 +632,20 @@ class AutoMapperHelpers:
         )
 
     @staticmethod
+    def first_provided_column(
+        *columns: AutoMapperColumnOrColumnLikeType,
+    ) -> "AutoMapperDataTypeBase":
+        """
+        Allows for columns to be defined based in which a source column may not exist. If the optional source column does
+         not exist, the "default" column definition is used instead.
+
+         :return: a optional automapper type
+        """
+        from spark_auto_mapper.data_types.first_provided_column import AutoMapperFirstProvidedColumnType
+
+        return AutoMapperFirstProvidedColumnType(*columns)
+
+    @staticmethod
     def optional(
         column: AutoMapperColumnOrColumnLikeType,
         default: Optional[AutoMapperColumnOrColumnLikeType],

--- a/tests/first_provided_column/test_automapper_first_provided_column.py
+++ b/tests/first_provided_column/test_automapper_first_provided_column.py
@@ -1,0 +1,106 @@
+from typing import Dict
+
+from pyspark.sql import SparkSession, Column, DataFrame
+# noinspection PyUnresolvedReferences
+from pyspark.sql.functions import lit, col
+
+from spark_auto_mapper.automappers.automapper import AutoMapper
+from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
+
+
+def test_automapper_first_provided_column(spark_session: SparkSession) -> None:
+    # Arrange
+    spark_session.createDataFrame(
+        [
+            (1, 'Qureshi', 'Imran', '54'),
+            (2, 'Vidal', 'Michael', '33'),
+        ], ['member_id', 'last_name', 'first_name', "my_age"]
+    ).createOrReplaceTempView("patients")
+
+    source_df_1: DataFrame = spark_session.table("patients")
+
+    df = source_df_1.select("member_id")
+    df.createOrReplaceTempView("members")
+
+    # The key thing in this test is that we are using the same mapper on sources with different columns, and they both
+    # work as expected.
+
+    # Act
+    mapper = AutoMapper(
+        view="members",
+        source_view="patients",
+        keys=["member_id"],
+        drop_key_columns=False
+    ).columns(
+        last_name=A.column("last_name"),
+        age=A.first_provided_column(
+            A.number(A.column("age")),
+            A.number(A.column("my_age")),
+            lit(None),
+        ),
+        age2=A.first_provided_column(
+            A.if_not_null(
+                A.first_provided_column(
+                    A.number(A.column("age")), A.number(A.column("my_age")),
+                    lit(None)
+                ),
+                A.first_provided_column(
+                    A.number(A.column("age")), A.number(A.column("my_age")),
+                    lit(None)
+                ), A.number(A.text("100"))
+            ), A.number(A.column("age")), A.number(A.column("his_age")),
+            lit(99999)
+        ),
+    )
+
+    assert isinstance(mapper, AutoMapper)
+    sql_expressions_1: Dict[str, Column] = mapper.get_column_specs(
+        source_df=source_df_1
+    )
+    for column_name, sql_expression in sql_expressions_1.items():
+        print(f"{column_name}: {sql_expression}")
+
+    assert str(sql_expressions_1["age"]
+               ) == str(col("b.my_age").cast("long").alias("age"))
+    result_df_1: DataFrame = mapper.transform(df=df)
+
+    spark_session.createDataFrame(
+        [
+            (1, 'Qureshi', 'Imran', '54'),
+            (2, 'Vidal', 'Michael', None),
+        ], ['member_id', 'last_name', 'first_name', "age"]
+    ).createOrReplaceTempView("patients")
+
+    source_df_2 = spark_session.table("patients")
+
+    df = source_df_1.select("member_id")
+    df.createOrReplaceTempView("members")
+
+    sql_expressions_2: Dict[str, Column] = mapper.get_column_specs(
+        source_df=source_df_2
+    )
+    assert str(sql_expressions_2["age"]
+               ) == str(col("b.age").cast("long").alias("___age"))
+
+    result_df_2 = mapper.transform(df=df)
+
+    # Assert
+    result_df_1.printSchema()
+    result_df_1.show()
+
+    result_df_2.printSchema()
+    result_df_2.show()
+
+    assert result_df_1.where("member_id == 1"
+                             ).select("age",
+                                      "age2").collect()[0][:] == (54, 54)
+    assert result_df_1.where("member_id == 2"
+                             ).select("age",
+                                      "age2").collect()[0][:] == (33, 33)
+
+    assert result_df_2.where("member_id == 1"
+                             ).select("age",
+                                      "age2").collect()[0][:] == (54, 54)
+    assert result_df_2.where("member_id == 2"
+                             ).select("age",
+                                      "age2").collect()[0][:] == (None, 100)

--- a/tests/first_valid_column/test_automapper_first_valid_column.py
+++ b/tests/first_valid_column/test_automapper_first_valid_column.py
@@ -8,7 +8,7 @@ from spark_auto_mapper.automappers.automapper import AutoMapper
 from spark_auto_mapper.helpers.automapper_helpers import AutoMapperHelpers as A
 
 
-def test_automapper_first_provided_column(spark_session: SparkSession) -> None:
+def test_automapper_first_valid_column(spark_session: SparkSession) -> None:
     # Arrange
     spark_session.createDataFrame(
         [
@@ -33,18 +33,18 @@ def test_automapper_first_provided_column(spark_session: SparkSession) -> None:
         drop_key_columns=False
     ).columns(
         last_name=A.column("last_name"),
-        age=A.first_provided_column(
+        age=A.first_valid_column(
             A.number(A.column("age")),
             A.number(A.column("my_age")),
             lit(None),
         ),
-        age2=A.first_provided_column(
+        age2=A.first_valid_column(
             A.if_not_null(
-                A.first_provided_column(
+                A.first_valid_column(
                     A.number(A.column("age")), A.number(A.column("my_age")),
                     lit(None)
                 ),
-                A.first_provided_column(
+                A.first_valid_column(
                     A.number(A.column("age")), A.number(A.column("my_age")),
                     lit(None)
                 ), A.number(A.text("100"))


### PR DESCRIPTION
Like coalesce, but works on columns/column definitions that exist/are valid, rather than the contents of said columns.
Useful for data sources in which columns may be renamed at some point and you want to process files from before and after the name change or when columns are added at a point and are missing from earlier files.