### PR TITLE
Update base data types to cast based on source schema

### DIFF
--- a/spark_auto_mapper/data_types/amount.py
+++ b/spark_auto_mapper/data_types/amount.py
@@ -2,7 +2,6 @@ from typing import Optional
 from deprecated import deprecated
 
 from pyspark.sql import Column, DataFrame
-from spark_auto_mapper.data_types.literal import AutoMapperDataTypeLiteral
 
 from spark_auto_mapper.data_types.column import AutoMapperDataTypeColumn
 from spark_auto_mapper.data_types.data_type_base import AutoMapperDataTypeBase
@@ -24,14 +23,8 @@ class AutoMapperAmountDataType(AutoMapperDataTypeBase):
     def get_column_spec(
         self, source_df: Optional[DataFrame], current_column: Optional[Column]
     ) -> Column:
-        if isinstance(self.value, AutoMapperDataTypeLiteral):
-            # parse the amount here
-            column_spec = self.value.get_column_spec(
-                source_df=source_df, current_column=current_column
-            ).cast("double")
-            return column_spec
         if source_df is not None and isinstance(self.value, AutoMapperDataTypeColumn) \
-                and dict(source_df.dtypes)[self.value.value] == "string":
+                and dict(source_df.dtypes)[self.value.value] not in ("float", "double"):
             # parse the amount here
             column_spec = self.value.get_column_spec(
                 source_df=source_df, current_column=current_column

--- a/spark_auto_mapper/data_types/boolean.py
+++ b/spark_auto_mapper/data_types/boolean.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from pyspark.sql import Column, DataFrame
-from spark_auto_mapper.data_types.literal import AutoMapperDataTypeLiteral
 
 from spark_auto_mapper.data_types.column import AutoMapperDataTypeColumn
 from spark_auto_mapper.data_types.data_type_base import AutoMapperDataTypeBase
@@ -19,14 +18,8 @@ class AutoMapperBooleanDataType(AutoMapperDataTypeBase):
     def get_column_spec(
         self, source_df: Optional[DataFrame], current_column: Optional[Column]
     ) -> Column:
-        if isinstance(self.value, AutoMapperDataTypeLiteral):
-            # parse the boolean here
-            column_spec = self.value.get_column_spec(
-                source_df=source_df, current_column=current_column
-            ).cast("boolean")
-            return column_spec
-        elif source_df is not None and isinstance(self.value, AutoMapperDataTypeColumn) \
-                and dict(source_df.dtypes)[self.value.value] == "string":
+        if source_df is not None and isinstance(self.value, AutoMapperDataTypeColumn) \
+                and dict(source_df.dtypes)[self.value.value] != "boolean":
             # parse the boolean here
             column_spec = self.value.get_column_spec(
                 source_df=source_df, current_column=current_column

--- a/spark_auto_mapper/data_types/decimal.py
+++ b/spark_auto_mapper/data_types/decimal.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from pyspark.sql import Column, DataFrame
 from pyspark.sql.types import DecimalType
-from spark_auto_mapper.data_types.literal import AutoMapperDataTypeLiteral
 
 from spark_auto_mapper.data_types.column import AutoMapperDataTypeColumn
 from spark_auto_mapper.data_types.data_type_base import AutoMapperDataTypeBase
@@ -30,20 +29,15 @@ class AutoMapperDecimalDataType(AutoMapperDataTypeBase):
     def get_column_spec(
         self, source_df: Optional[DataFrame], current_column: Optional[Column]
     ) -> Column:
-        if isinstance(self.value, AutoMapperDataTypeLiteral):
-            # parse the amount here
-            column_spec = self.value.get_column_spec(
-                source_df=source_df, current_column=current_column
-            ).cast(DecimalType(precision=self.precision, scale=self.scale))
-            return column_spec
         if source_df is not None and isinstance(self.value, AutoMapperDataTypeColumn) \
-                and dict(source_df.dtypes)[self.value.value] in ("string", "int", "long", "float", "double"):
+                and "decimal" not in dict(source_df.dtypes)[self.value.value]:
             # parse the amount here
             column_spec = self.value.get_column_spec(
                 source_df=source_df, current_column=current_column
             ).cast(DecimalType(precision=self.precision, scale=self.scale))
             return column_spec
         else:
+            # Already a decimal
             column_spec = self.value.get_column_spec(
                 source_df=source_df, current_column=current_column
             )

--- a/spark_auto_mapper/data_types/float.py
+++ b/spark_auto_mapper/data_types/float.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from pyspark.sql import Column, DataFrame
-from spark_auto_mapper.data_types.literal import AutoMapperDataTypeLiteral
 
 from spark_auto_mapper.data_types.column import AutoMapperDataTypeColumn
 from spark_auto_mapper.data_types.data_type_base import AutoMapperDataTypeBase
@@ -18,14 +17,8 @@ class AutoMapperFloatDataType(AutoMapperDataTypeBase):
     def get_column_spec(
         self, source_df: Optional[DataFrame], current_column: Optional[Column]
     ) -> Column:
-        if isinstance(self.value, AutoMapperDataTypeLiteral):
-            # parse the amount here
-            column_spec = self.value.get_column_spec(
-                source_df=source_df, current_column=current_column
-            ).cast("float")
-            return column_spec
         if isinstance(self.value, AutoMapperDataTypeColumn) and source_df is not None \
-                and dict(source_df.dtypes)[self.value.value] == "string":
+                and dict(source_df.dtypes)[self.value.value] not in ("float", "double"):
             # parse the amount here
             column_spec = self.value.get_column_spec(
                 source_df=source_df, current_column=current_column

--- a/spark_auto_mapper/data_types/number.py
+++ b/spark_auto_mapper/data_types/number.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from pyspark.sql import Column, DataFrame
-from spark_auto_mapper.data_types.literal import AutoMapperDataTypeLiteral
 
 from spark_auto_mapper.data_types.column import AutoMapperDataTypeColumn
 from spark_auto_mapper.data_types.data_type_base import AutoMapperDataTypeBase
@@ -19,22 +18,16 @@ class AutoMapperNumberDataType(AutoMapperDataTypeBase):
     def get_column_spec(
         self, source_df: Optional[DataFrame], current_column: Optional[Column]
     ) -> Column:
-        if isinstance(self.value, AutoMapperDataTypeLiteral) \
-                and isinstance(self.value.value, str):
-            # parse the amount here
-            column_spec = self.value.get_column_spec(
-                source_df=source_df, current_column=current_column
-            ).cast("long")
-            return column_spec
         if source_df is not None and isinstance(self.value, AutoMapperDataTypeColumn) \
-                and dict(source_df.dtypes)[self.value.value] == "string":
-            # parse the amount here
-            column_spec = self.value.get_column_spec(
-                source_df=source_df, current_column=current_column
-            ).cast("long")
-            return column_spec
-        else:
+                and dict(source_df.dtypes)[self.value.value] in ("long", "int", "bigint"):
+            # Don't parse to long if it's already a long
             column_spec = self.value.get_column_spec(
                 source_df=source_df, current_column=current_column
             )
+            return column_spec
+        else:
+            # parse the amount here
+            column_spec = self.value.get_column_spec(
+                source_df=source_df, current_column=current_column
+            ).cast("long")
             return column_spec

--- a/tests/first_valid_column/test_automapper_first_valid_column_expressions.py
+++ b/tests/first_valid_column/test_automapper_first_valid_column_expressions.py
@@ -66,7 +66,7 @@ def test_automapper_first_valid_column(spark_session: SparkSession) -> None:
         print(f"{column_name}: {sql_expression}")
 
     assert str(sql_expressions["age"]
-               ) == str(col("my_age").cast("long").alias("age"))
+               ) == str(col("my_age").cast("long").cast("long").alias("age"))
     result_df: DataFrame = mapper.transform(df=df)
 
     # Assert


### PR DESCRIPTION
Previously, if you had provided a literal (other than a string literal) no casting would take place.
We want the casting to take place, to ensure that our result schemas match what is expected.