### PR TITLE
Booleans should always be cast

### DIFF
--- a/spark_auto_mapper/data_types/boolean.py
+++ b/spark_auto_mapper/data_types/boolean.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 from pyspark.sql import Column, DataFrame
 
-from spark_auto_mapper.data_types.column import AutoMapperDataTypeColumn
 from spark_auto_mapper.data_types.data_type_base import AutoMapperDataTypeBase
 from spark_auto_mapper.helpers.value_parser import AutoMapperValueParser
 from spark_auto_mapper.type_definitions.defined_types import AutoMapperBooleanInputType
@@ -18,15 +17,8 @@ class AutoMapperBooleanDataType(AutoMapperDataTypeBase):
     def get_column_spec(
         self, source_df: Optional[DataFrame], current_column: Optional[Column]
     ) -> Column:
-        if source_df is not None and isinstance(self.value, AutoMapperDataTypeColumn) \
-                and dict(source_df.dtypes)[self.value.value] != "boolean":
-            # parse the boolean here
-            column_spec = self.value.get_column_spec(
-                source_df=source_df, current_column=current_column
-            ).cast("boolean")
-            return column_spec
-        else:
-            column_spec = self.value.get_column_spec(
-                source_df=source_df, current_column=current_column
-            )
-            return column_spec
+        # parse the boolean here
+        column_spec = self.value.get_column_spec(
+            source_df=source_df, current_column=current_column
+        ).cast("boolean")
+        return column_spec

--- a/tests/boolean/test_automapper_boolean_typed.py
+++ b/tests/boolean/test_automapper_boolean_typed.py
@@ -35,7 +35,8 @@ def test_auto_mapper_boolean_typed(spark_session: SparkSession) -> None:
     for column_name, sql_expression in sql_expressions.items():
         print(f"{column_name}: {sql_expression}")
 
-    assert str(sql_expressions["age"]) == str(col("b.my_age").alias("age"))
+    assert str(sql_expressions["age"]
+               ) == str(col("b.my_age").cast("boolean").alias("age"))
 
     result_df: DataFrame = mapper.transform(df=df)
 


### PR DESCRIPTION
Previous commit worked, but some entries were not being cast. This just forces everything to be cast to boolean as I can't think of a reason why we wouldn't.